### PR TITLE
fix: 🐛 handle nested TypeScript projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 
 # Compiled files
 /dist
+
+# VS Code
+/.vscode

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -130,10 +130,7 @@ export async function get_config() {
  * @param currentDir
  * @param project
  */
-export function get_ts_config(
-	currentDir: string,
-	project: string
-): ParsedCommandLine {
+export function get_ts_config(currentDir: string, project: string): ParsedCommandLine {
 	let configFile = ts.findConfigFile(currentDir, ts.sys.fileExists, project);
 
 	if (!configFile) {
@@ -233,15 +230,15 @@ export function get_ignore_list(config: Config, projects: TsProject | TsProject[
 		const safe_projects = !Array.isArray(projects) ? [projects] : projects;
 
 		const ts_exclude_list = safe_projects.map((project) => {
-				return project.exclude.map((rule) => {
-					// Handle if the exclude pattern contains the name of the root directory
+		  return project.exclude.map((rule) => {
+			// Handle if the exclude pattern contains the name of the root directory
 				const rootDirName = project.root_dir.replace(project.base_path + '/', '') + '/';
-					if (rule.startsWith(rootDirName)) {
+				if (rule.startsWith(rootDirName)) {
 					return rule.replace(rootDirName, '');
-					}
+				}
 
-					return rule;
-				});
+				return rule;
+			});
 		}).flat();
 
 		ignore_list.push(...ts_exclude_list);
@@ -416,18 +413,18 @@ async function apply_loaders(raw_content: string, source_path: string, destinati
 			return [...rule.use].reverse().reduce((content, loader) => {
 				let loaderFn;
 
-				switch (typeof loader.loader) {
+				  switch (typeof loader.loader) {
 						case 'function':
-						loaderFn = loader.loader;
-						break;
+						  loaderFn = loader.loader;
+						  break;
 						case 'string':
-						loaderFn = require(path.resolve(loader.loader));
-						break;
-					default:
+						  loaderFn = require(path.resolve(loader.loader));
+						  break;
+					  default:
 							throw new Error('Invalid loader type');
-				}
+				  }
 
-				return loaderFn(content, loaderMeta);
+				  return loaderFn(content, loaderMeta);
 				},
 				processed_content,
 			);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -230,8 +230,8 @@ export function get_ignore_list(config: Config, projects: TsProject | TsProject[
 		const safe_projects = !Array.isArray(projects) ? [projects] : projects;
 
 		const ts_exclude_list = safe_projects.map((project) => {
-		  return project.exclude.map((rule) => {
-			// Handle if the exclude pattern contains the name of the root directory
+			return project.exclude.map((rule) => {
+				// Handle if the exclude pattern contains the name of the root directory
 				const rootDirName = project.root_dir.replace(project.base_path + '/', '') + '/';
 				if (rule.startsWith(rootDirName)) {
 					return rule.replace(rootDirName, '');
@@ -411,20 +411,20 @@ async function apply_loaders(raw_content: string, source_path: string, destinati
 
 		processed_content = await used_rules.reduce((content, rule) => {
 			return [...rule.use].reverse().reduce((content, loader) => {
-				let loaderFn;
+					let loaderFn;
 
-				  switch (typeof loader.loader) {
+					switch (typeof loader.loader) {
 						case 'function':
-						  loaderFn = loader.loader;
-						  break;
+							loaderFn = loader.loader;
+							break;
 						case 'string':
-						  loaderFn = require(path.resolve(loader.loader));
-						  break;
-					  default:
+							loaderFn = require(path.resolve(loader.loader));
+							break;
+						default:
 							throw new Error('Invalid loader type');
-				  }
+					}
 
-				  return loaderFn(content, loaderMeta);
+					return loaderFn(content, loaderMeta);
 				},
 				processed_content,
 			);


### PR DESCRIPTION
A tsconfig file can have a `reference` in it that points to another project by a directory name rather than specifically to the tsconfig.json file in it.

This change handles this case - if the attempt to get the configuration file fails, we check to see if the project is actually a directory, and, if it is, we try again with an explicit reference to a config file.

I was in two minds as to whether or not to do the check first; I decided to do it after since that's least disruptive to anyone's currently working workflow.