### PR TITLE
Ignore projects where emitting is disabled

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -174,7 +174,7 @@ export function get_ts_project_paths(options: Config): TsProject {
 	if (project.no_emit) {
 		throw new Error('Project must have emitting enabled');
 	}
-	
+
 	return project;
 }
 
@@ -206,7 +206,7 @@ export function get_ts_projects_paths(options: Config): TsProject[] {
 	});
 
 	const projects_with_emit = projects.filter((project) => project.no_emit === false);
-	if (!projects_with_emit) {
+	if (projects_with_emit.length === 0) {
 		throw new Error('At least one project must have emitting enabled');
 	}
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -195,8 +195,12 @@ export function get_ts_projects_paths(options: Config): TsProject[] {
 
 		const referenceConfig = get_ts_config(cwd, reference.originalPath!);
 
+		if (referenceConfig.options.noEmit) {
+			return null;
+		}
+
 		return build_project_path(cwd, reference.originalPath!, referenceConfig);
-	});
+	}).filter((project): project is TsProject => project !== null);
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,7 @@ export type TsProject = {
 	root_dir: string;
 	out_dir: string;
 	exclude: string[];
+	no_emit: boolean;
 }
 
 export type TsProjectWithFiles = TsProject & {


### PR DESCRIPTION
Closes #14.

I did not make any changes to the non-`build` branch of code (that is, `get_ts_project_paths`), as I figured it doesn't make any sense to use this package with a single project where emitting is disabled.